### PR TITLE
Fix stream problem for large data

### DIFF
--- a/internal/output/grpc/grpc.go
+++ b/internal/output/grpc/grpc.go
@@ -36,6 +36,8 @@ type CertOpts struct {
 	Insecure   bool
 }
 
+// NewGRPCStreamClient creates a new gRPC client that streams data to the server
+// Deprecated: Use NewStreamManager instead
 func NewGRPCStreamClient(mainCtx context.Context, server string, port int, certOpts CertOpts, maxMessageSize int) (*Messenger, error) {
 	ctx, cancel := context.WithCancel(mainCtx)
 

--- a/internal/output/grpc/grpc.go
+++ b/internal/output/grpc/grpc.go
@@ -116,9 +116,10 @@ func (g *Messenger) StreamData(ctx context.Context, payloads []*pb.SensorEvent) 
 		log.WithField("package", "grpc").Infoln("Context is done. Stopping the stream.")
 		return nil
 	default:
+		// initialize the stream
 		stream, err := g.client.StreamData(ctx)
 		if err != nil {
-			//log.Fatalf("Failed to open stream: %v", err)
+			log.Errorf("Failed to open stream: %v", err)
 			return err
 		}
 

--- a/internal/output/grpc/stream_manager.go
+++ b/internal/output/grpc/stream_manager.go
@@ -1,0 +1,144 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"github.com/mata-elang-stable/sensor-snort-service/internal/pb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"sync"
+	"time"
+)
+
+// StreamManager wraps your gRPC stream and auto-closes it after a timeout.
+type StreamManager struct {
+	client  pb.SensorServiceClient
+	mu      sync.Mutex
+	stream  pb.SensorService_StreamDataClient
+	timer   *time.Timer
+	timeout time.Duration
+}
+
+// NewStreamManager creates a new StreamManager.
+func NewStreamManager(server string, port int, certOpts CertOpts, maxMessageSize int, timeout time.Duration) (*StreamManager, error) {
+	var creds credentials.TransportCredentials
+	var err error
+
+	if certOpts.Insecure {
+		creds = insecure.NewCredentials()
+	} else {
+		creds, err = credentials.NewClientTLSFromFile(certOpts.CertFile, certOpts.ServerName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	conn, err := grpc.NewClient(
+		fmt.Sprintf("%s:%d", server, port),
+		grpc.WithTransportCredentials(creds),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxMessageSize*1024*1024),
+			grpc.MaxCallSendMsgSize(maxMessageSize*1024*1024),
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &StreamManager{
+		client:  pb.NewSensorServiceClient(conn),
+		timeout: timeout,
+	}, nil
+}
+
+// getStream returns an active stream. If none exists, it creates one.
+func (sm *StreamManager) getStream() (pb.SensorService_StreamDataClient, error) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if sm.stream != nil {
+		sm.resetTimer() // Reset the timeout on activity.
+		return sm.stream, nil
+	}
+
+	log.Infoln("Reconnecting to stream")
+
+	stream, err := sm.client.StreamData(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	sm.stream = stream
+	sm.resetTimer()
+	return sm.stream, nil
+}
+
+// resetTimer resets the inactivity timer.
+func (sm *StreamManager) resetTimer() {
+	if sm.timer != nil {
+		sm.timer.Stop()
+	}
+	sm.timer = time.AfterFunc(sm.timeout, func() {
+		sm.mu.Lock()
+		defer sm.mu.Unlock()
+		log.Println("Timeout reached; closing stream")
+		if sm.stream != nil {
+			sm.stream.CloseSend()
+			sm.stream = nil
+		}
+	})
+}
+
+// SendEvent sends an event over the stream and resets the timer.
+func (sm *StreamManager) SendEvent(event *pb.SensorEvent) error {
+	stream, err := sm.getStream()
+	if err != nil {
+		return err
+	}
+	if err := stream.Send(event); err != nil {
+		// If sending fails, close the stream so that it will be reestablished next time.
+		sm.mu.Lock()
+		sm.stream = nil
+		sm.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
+func (sm *StreamManager) SendBulkEvent(ctx context.Context, events []*pb.SensorEvent) (int64, error) {
+	stream, err := sm.getStream()
+	if err != nil {
+		return 0, err
+	}
+
+	totalEvents := int64(0)
+
+	for i := 0; i < len(events); {
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		default:
+			if err := stream.Send(events[i]); err != nil {
+				// If sending fails, close the stream so that it will be reestablished next time.
+				sm.mu.Lock()
+				sm.stream = nil
+				sm.mu.Unlock()
+				continue
+			}
+
+			totalEvents += events[i].EventMetricsCount
+			i++
+		}
+	}
+
+	return totalEvents, nil
+}
+
+func (sm *StreamManager) Close() {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if sm.stream != nil {
+		sm.stream.CloseSend()
+		sm.stream = nil
+	}
+}


### PR DESCRIPTION
This pull request introduces several significant changes to the `cmd/client.go`, `cmd/server.go`, `internal/kafka_producer/kafka_producer.go`, `internal/output/grpc/grpc.go`, and `internal/queue/queue.go` files. The changes include the introduction of a new `StreamManager` for managing gRPC streams, updates to the Kafka producer configuration, and improvements to logging and metrics recording.

### Introduction of `StreamManager` for gRPC streams:
* [`cmd/client.go`](diffhunk://#diff-77cc8dd5b2fc01f2cbc5f714d0ae7ac6cf20bf5dc4eba6733bd3edbc5eefb7d9L108-L115): Replaced `grpc.NewGRPCStreamClient` with `grpc.NewStreamManager` for creating the gRPC stream client, and updated the event queue watcher to use `streamManager` instead of `grpcClient`. [[1]](diffhunk://#diff-77cc8dd5b2fc01f2cbc5f714d0ae7ac6cf20bf5dc4eba6733bd3edbc5eefb7d9L108-L115) [[2]](diffhunk://#diff-77cc8dd5b2fc01f2cbc5f714d0ae7ac6cf20bf5dc4eba6733bd3edbc5eefb7d9L125-R164)
* [`internal/output/grpc/stream_manager.go`](diffhunk://#diff-71709a617de11ace8e03a5bf634d194686b7c9f2cdba5a42c6127a04d4aaa593R1-R144): Added a new `StreamManager` class to manage gRPC streams with auto-closing functionality after a timeout.
* [`internal/queue/queue.go`](diffhunk://#diff-f25aa22bb32d5ce7ba81f10e5d21521bc7a095cc7e2f970c3bb494f94cca976bL68-R77): Updated the `StartWatcher` method to use `StreamManager` instead of `Messenger` for handling gRPC streams. [[1]](diffhunk://#diff-f25aa22bb32d5ce7ba81f10e5d21521bc7a095cc7e2f970c3bb494f94cca976bL68-R77) [[2]](diffhunk://#diff-f25aa22bb32d5ce7ba81f10e5d21521bc7a095cc7e2f970c3bb494f94cca976bR86-L101)

### Kafka producer configuration updates:
* [`internal/kafka_producer/kafka_producer.go`](diffhunk://#diff-859acd0cca163c6ba1288626b5f6524065c6601a35cc82b1884bb786ec244e71L25-R33): Added new configuration options `linger.ms`, `batch.size`, `message.max.bytes`, and `go.batch.producer` to the Kafka producer.
* Updated logging to use `log.Tracef` instead of `log.Debugf` for produced messages, and added error logging for failed message production.

### Logging and metrics recording improvements:
* [`cmd/client.go`](diffhunk://#diff-77cc8dd5b2fc01f2cbc5f714d0ae7ac6cf20bf5dc4eba6733bd3edbc5eefb7d9L125-R164): Added log messages to indicate the start of various components (Watcher, File Listener, Prometheus Exporter Server, and metrics recorder). [[1]](diffhunk://#diff-77cc8dd5b2fc01f2cbc5f714d0ae7ac6cf20bf5dc4eba6733bd3edbc5eefb7d9L125-R164) [[2]](diffhunk://#diff-77cc8dd5b2fc01f2cbc5f714d0ae7ac6cf20bf5dc4eba6733bd3edbc5eefb7d9L170-L184)
* Removed detailed metrics logging based on log level from the metrics recorder.

### Deprecation of `NewGRPCStreamClient`:
* [`internal/output/grpc/grpc.go`](diffhunk://#diff-38aeef6a063f74ab390110710d591dd6d332073700b93aa96280f6912e7413a2R39-R40): Marked `NewGRPCStreamClient` as deprecated and added a comment to use `NewStreamManager` instead.

### Minor changes:
* [`cmd/server.go`](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197R76-R83): Added a new counter `currentSessionBatchCount` to track the number of batches received in the gRPC stream. [[1]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197R76-R83) [[2]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197R96)
* Removed unused import `semaphore` from `internal/queue/queue.go`.