### PR TITLE
Refactor SendBulkEvent to use SendEvent for improved stream handling

### DIFF
--- a/internal/output/grpc/stream_manager.go
+++ b/internal/output/grpc/stream_manager.go
@@ -106,11 +106,6 @@ func (sm *StreamManager) SendEvent(event *pb.SensorEvent) error {
 }
 
 func (sm *StreamManager) SendBulkEvent(ctx context.Context, events []*pb.SensorEvent) (int64, error) {
-	stream, err := sm.getStream()
-	if err != nil {
-		return 0, err
-	}
-
 	totalEvents := int64(0)
 
 	for i := 0; i < len(events); {
@@ -118,11 +113,7 @@ func (sm *StreamManager) SendBulkEvent(ctx context.Context, events []*pb.SensorE
 		case <-ctx.Done():
 			return 0, ctx.Err()
 		default:
-			if err := stream.Send(events[i]); err != nil {
-				// If sending fails, close the stream so that it will be reestablished next time.
-				sm.mu.Lock()
-				sm.stream = nil
-				sm.mu.Unlock()
+			if err := sm.SendEvent(events[i]); err != nil {
 				continue
 			}
 


### PR DESCRIPTION
This pull request includes a significant change to the `StreamManager`'s `SendBulkEvent` method in the `internal/output/grpc/stream_manager.go` file. The main change refactors the way events are sent by utilizing the `SendEvent` method instead of directly interacting with the stream.

Refactoring for event sending:

* [`internal/output/grpc/stream_manager.go`](diffhunk://#diff-71709a617de11ace8e03a5bf634d194686b7c9f2cdba5a42c6127a04d4aaa593L109-R116): Modified the `SendBulkEvent` method to call the `SendEvent` method for sending individual events instead of directly sending them through the stream. This change simplifies the error handling and stream management logic.