### PR TITLE
feat: add dual-mode listener support with --file and --socket flags

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -101,7 +101,7 @@ func runClient(cmd *cobra.Command, args []string) {
 	defer cancel()
 
 	// Create the appropriate listener: --socket flag triggers unix socket, otherwise file
-	var l listener.Listener
+	var lis listener.Listener
 	var err error
 
 	if cmd.Flags().Changed("file") && cmd.Flags().Changed("socket") {
@@ -109,14 +109,14 @@ func runClient(cmd *cobra.Command, args []string) {
 	}
 
 	if cmd.Flags().Changed("socket") {
-		l, err = listener.NewUnixListener(conf.AlertSocketPath)
+		lis, err = listener.NewUnixListener(conf.AlertSocketPath)
 		if err != nil {
 			log.WithField("error", err).Fatalln("failed to create socket listener")
 			return
 		}
 		log.Infoln("Using unix socket listener")
 	} else {
-		l, err = listener.NewFileListener(conf.AlertFilePath)
+		lis, err = listener.NewFileListener(conf.AlertFilePath)
 		if err != nil {
 			log.WithField("error", err).Fatalln("failed to create file listener")
 			return
@@ -156,7 +156,7 @@ func runClient(cmd *cobra.Command, args []string) {
 	g.Go(func() error {
 		defer cancel()
 		log.Infof("Starting Listener...")
-		err := l.Start(gCtx, eventQueue)
+		err := lis.Start(gCtx, eventQueue)
 		defer log.WithField("package", "main").Infof("Listener Job is stopped. (%v)\n", err)
 		return err
 	})
@@ -176,7 +176,7 @@ func runClient(cmd *cobra.Command, args []string) {
 		log.Infof("Shutting down the client...")
 
 		streamManager.Close()
-		return l.Stop()
+		return lis.Stop()
 	})
 
 	// Record metrics every second using the prometheus exporter
@@ -197,7 +197,7 @@ func runClient(cmd *cobra.Command, args []string) {
 				cancel()
 				return nil
 			case <-ticker.C:
-				prom.RecordMetrics(l, eventQueue)
+				prom.RecordMetrics(lis, eventQueue)
 			}
 		}
 	})

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -35,6 +35,7 @@ func init() {
 
 	clientConfig := conf.Client()
 	viper.SetDefault("file", "/var/log/snort/alert_json.txt")
+	viper.SetDefault("socket", "/var/run/snort/alert.sock")
 	viper.SetDefault("server", "localhost")
 	viper.SetDefault("port", 50051)
 	viper.SetDefault("interval", 1*time.Second)
@@ -54,8 +55,10 @@ func init() {
 
 	flags := clientCmd.PersistentFlags()
 
-	flags.StringVarP(&clientConfig.SnortAlertFile, "file", "f", clientConfig.SnortAlertFile,
+	flags.StringVarP(&clientConfig.AlertFilePath, "file", "f", clientConfig.AlertFilePath,
 		"Specifies the path to the Snort alert file.")
+	flags.StringVar(&clientConfig.AlertSocketPath, "socket", clientConfig.AlertSocketPath,
+		"Specifies the path to the Snort alert unix socket.")
 	flags.StringVarP(&clientConfig.GRPCServer, "server", "s", clientConfig.GRPCServer, "Specifies the gRPC server.")
 	flags.IntVarP(&clientConfig.GRPCPort, "port", "p", clientConfig.GRPCPort, "Specifies the gRPC port.")
 	flags.BoolVar(&clientConfig.GRPCSecure, "secure", clientConfig.GRPCSecure, "Specifies whether the connection is secure or not.")
@@ -81,7 +84,8 @@ func runClient(cmd *cobra.Command, args []string) {
 	conf := confInstance.Client()
 
 	log.Infof("Starting server with configuration:")
-	log.Infof("SnortAlertFile: %s", conf.SnortAlertFile)
+	log.Infof("AlertFilePath: %s", conf.AlertFilePath)
+	log.Infof("AlertSocketPath: %s", conf.AlertSocketPath)
 	log.Infof("GRPCServer: %s", conf.GRPCServer)
 	log.Infof("GRPCPort: %d", conf.GRPCPort)
 	log.Infof("GRPCSecure: %t", conf.GRPCSecure)
@@ -96,11 +100,28 @@ func runClient(cmd *cobra.Command, args []string) {
 	mainContext, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	// Create a unix socket listener
-	unixListener, err := listener.NewUnixListener(conf.SnortAlertFile)
-	if err != nil {
-		log.WithField("error", err).Fatalln("failed to create unix listener")
-		return
+	// Create the appropriate listener: --socket flag triggers unix socket, otherwise file
+	var l listener.Listener
+	var err error
+
+	if cmd.Flags().Changed("file") && cmd.Flags().Changed("socket") {
+		log.Fatalln("cannot specify both --file and --socket; choose one")
+	}
+
+	if cmd.Flags().Changed("socket") {
+		l, err = listener.NewUnixListener(conf.AlertSocketPath)
+		if err != nil {
+			log.WithField("error", err).Fatalln("failed to create socket listener")
+			return
+		}
+		log.Infoln("Using unix socket listener")
+	} else {
+		l, err = listener.NewFileListener(conf.AlertFilePath)
+		if err != nil {
+			log.WithField("error", err).Fatalln("failed to create file listener")
+			return
+		}
+		log.Infoln("Using file listener")
 	}
 
 	// Create an event queue to store sensor events
@@ -131,12 +152,12 @@ func runClient(cmd *cobra.Command, args []string) {
 		return err
 	})
 
-	// Start the unix listener
+	// Start the listener
 	g.Go(func() error {
 		defer cancel()
-		log.Infof("Starting Unix Listener...")
-		err := unixListener.Start(gCtx, eventQueue)
-		defer log.WithField("package", "main").Infof("Unix Listener Job is stopped. (%v)\n", err)
+		log.Infof("Starting Listener...")
+		err := l.Start(gCtx, eventQueue)
+		defer log.WithField("package", "main").Infof("Listener Job is stopped. (%v)\n", err)
 		return err
 	})
 
@@ -155,7 +176,7 @@ func runClient(cmd *cobra.Command, args []string) {
 		log.Infof("Shutting down the client...")
 
 		streamManager.Close()
-		return unixListener.Stop()
+		return l.Stop()
 	})
 
 	// Record metrics every second using the prometheus exporter
@@ -176,7 +197,7 @@ func runClient(cmd *cobra.Command, args []string) {
 				cancel()
 				return nil
 			case <-ticker.C:
-				prom.RecordMetrics(unixListener, eventQueue)
+				prom.RecordMetrics(l, eventQueue)
 			}
 		}
 	})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,8 +11,11 @@ import (
 )
 
 type ClientConfig struct {
-	// SnortAlertFile is the file to read the Snort alert from.
-	SnortAlertFile string `mapstructure:"file"`
+	// AlertFilePath is the path to the Snort alert file (used with --file flag).
+	AlertFilePath string `mapstructure:"file"`
+
+	// AlertSocketPath is the path to the Snort alert unix socket (used with --socket flag).
+	AlertSocketPath string `mapstructure:"socket"`
 
 	// GRPCServer is the server to connect to.
 	GRPCServer string `mapstructure:"server"`

--- a/internal/listener/file_listener.go
+++ b/internal/listener/file_listener.go
@@ -103,6 +103,14 @@ MainLoop:
 			payload.Metadata.ReadAt = time.Now().UnixMicro()
 			pbRecord, metric := processor.ConvertSnortAlertToSensorEvent(&payload)
 
+			if pbRecord == nil || metric == nil {
+				log.WithFields(logger.Fields{
+					"package": "file_listener",
+					"reason":  "nil return from ConvertSnortAlertToSensorEvent",
+				}).Debugln("skipping event")
+				continue MainLoop
+			}
+
 			q.AddRecordToQueue(pbRecord, metric)
 			f.linesThisSec.Add(1)
 		}

--- a/internal/listener/unix_listener.go
+++ b/internal/listener/unix_listener.go
@@ -171,6 +171,8 @@ func (u *UnixListener) GetEventReadPerSecond() int64 {
 }
 
 // Stop stops the unix listener.
+// Closing u.conn ensures the scanner.Scan() loop in Start() unblocks,
+// allowing the Start() defer to clean up resources properly.
 func (u *UnixListener) Stop() error {
 	if u.conn != nil {
 		u.conn.Close()


### PR DESCRIPTION
## Summary
Enables the client to read Snort alerts from either a file or a unix socket, selectable via mutually exclusive `--file` and `--socket` flags.

## Changes
- **config**: Rename `SnortAlertFile` to `AlertFilePath` and add `AlertSocketPath`
- **client.go**: Add `--socket` flag; detect listener via `cmd.Flags().Changed("socket")`. Both flags together result in an error
- **FileListener**: Add nil check for processor output (consistency with UnixListener)
- **UnixListener**: Document `Stop()` connection close behavior

## Usage
```bash
# File listener (default, backward compatible)
sensor-snort-service client --file /var/log/snort/alert_json.txt

# Unix socket listener
sensor-snort-service client --socket /var/run/snort/alert.sock

# Both set — error
sensor-snort-service client --file /path --socket /path
# cannot specify both --file and --socket; choose one
```